### PR TITLE
Make autogen.sh work on OS X if it has glibtoolize instead of libtoolize

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -2,6 +2,13 @@
 rm -rf autom4te.cache
 aclocal -I m4
 autoheader
-libtoolize --copy
+if type libtoolize > /dev/null 2>&1; then
+  libtoolize --copy
+elif type glibtoolize > /dev/null 2>&1; then
+  glibtoolize --copy
+else
+  echo "ERROR: Could not find either libtoolize or glibtoolize" >&2;
+  exit 1;
+fi
 automake --add-missing --copy
 autoconf


### PR DESCRIPTION
Building snappy on OS X didn't work out of the box (for me, anyway), since OS X has glibtoolize rather than libtoolize. This change checks for libtoolize first, but falls back to glibtoolize if libtoolize is not found.
